### PR TITLE
Add symlinks to examples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use the `paypal.orders` connector in your Ballerina application, update the `
 Import the `paypal.orders` module.
 
 ```ballerina
-import ballerinax/paypal.orders;
+import ballerinax/paypal.orders as paypal;
 ```
 
 ### Step 2: Instantiate a new connector

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -45,7 +45,7 @@ To use the `paypal.orders` connector in your Ballerina application, update the `
 Import the `paypal.orders` module.
 
 ```ballerina
-import ballerinax/paypal.orders;
+import ballerinax/paypal.orders as paypal;
 ```
 
 ### Step 2: Instantiate a new connector

--- a/examples/manage-shipping/.github/README.md
+++ b/examples/manage-shipping/.github/README.md
@@ -1,0 +1,1 @@
+../Manage shipping.md

--- a/examples/order-lifecycle/.github/README.md
+++ b/examples/order-lifecycle/.github/README.md
@@ -1,0 +1,1 @@
+../Order lifecycle.md


### PR DESCRIPTION
## Purpose

Added symlinks in the `.github` directory pointing to individual example markdown files, since they use custom filenames instead of `README.md`.